### PR TITLE
Easier to implement datasource interface

### DIFF
--- a/pkg/backends/build.go
+++ b/pkg/backends/build.go
@@ -13,9 +13,6 @@ import (
 var (
 	_ = u.EMPTY
 
-	// Ensure that we implement the Exec Visitor interface
-	//_ expr.Visitor = (*Builder)(nil)
-
 	// Standard errors
 	ErrNotSupported     = fmt.Errorf("DataUX: Not supported")
 	ErrNotImplemented   = fmt.Errorf("DataUX: Not implemented")
@@ -28,59 +25,10 @@ const (
 	MaxAllowedPacket = 1024 * 1024
 )
 
-/*
-// This is a Sql Plan Builder that chooses backends
-//   and routes/manages Requests
-type Builder struct {
-	//svr *models.ServerCtx
-	*exec.SqlJob
-	//*exec.JobBuilder
-	//where      expr.Node
-	//children exec.Tasks
-	//writer   models.ResultWriter
-}
-*/
 // Create Job made up of sub-tasks in DAG that is the
 //   plan for execution of this query/job
 func BuildSqlJob(svr *models.ServerCtx, schemaDb, sqlText string) (*exec.SqlJob, error) {
-
 	return exec.BuildSqlProjectedJob(svr.RtConf, schemaDb, sqlText)
-	/*
-		stmt, err := expr.ParseSql(sqlText)
-		if err != nil {
-			u.Warnf("Could not parse: %v", err)
-			return nil, err
-		}
-
-		sqlJob := &exec.SqlJob{
-			Stmt: stmt,
-			Conf: svr.RtConf,
-		}
-		execBuilder := exec.NewJobBuilder(svr.RtConf, schemaDb)
-
-		builder := NewBuilder(svr, sqlJob, schemaDb)
-		builder.JobBuilder = execBuilder
-
-		//u.LogTracef(u.WARN, "BuildSqlJob: schema='%s'  %#v", schemaDb, builder.schema)
-		u.Debugf("BuildSqlJob: schema='%s'  %#v", schemaDb, builder.Schema)
-		task, err := stmt.Accept(builder)
-		if err != nil {
-			u.Warnf("Could not build %v", err)
-			return nil, err
-		}
-		if task == nil {
-			// If No Error, and no Exec Tasks, then we already wrote results
-			return nil, nil
-		}
-		tr, ok := task.(exec.TaskRunner)
-		if !ok {
-			return nil, fmt.Errorf("Could not convert %T to TaskRunner", task)
-		}
-		builder.RootTask = tr
-
-		return builder, nil
-	*/
-
 }
 
 /*

--- a/pkg/backends/build.go
+++ b/pkg/backends/build.go
@@ -2,15 +2,11 @@ package backends
 
 import (
 	"fmt"
-	"strings"
 
 	u "github.com/araddon/gou"
 
-	//"github.com/araddon/qlbridge/datasource"
-	"github.com/araddon/qlbridge/datasource/membtree"
 	"github.com/araddon/qlbridge/exec"
-	"github.com/araddon/qlbridge/expr"
-	"github.com/araddon/qlbridge/value"
+	//"github.com/araddon/qlbridge/expr"
 	"github.com/dataux/dataux/pkg/models"
 )
 
@@ -18,7 +14,7 @@ var (
 	_ = u.EMPTY
 
 	// Ensure that we implement the Exec Visitor interface
-	_ expr.Visitor = (*Builder)(nil)
+	//_ expr.Visitor = (*Builder)(nil)
 
 	// Standard errors
 	ErrNotSupported     = fmt.Errorf("DataUX: Not supported")
@@ -33,63 +29,61 @@ const (
 )
 
 /*
-
-Source ->  Where  -> GroupBy/Counts etc  -> Projection -> ResultWriter
-
-- Since we don't really need the Where, GroupBy, etc
-
-Source ->    Projection  -> ResultWriter
-
-
-type JobRunner interface {
-	Run() error
-	Close() error
+// This is a Sql Plan Builder that chooses backends
+//   and routes/manages Requests
+type Builder struct {
+	//svr *models.ServerCtx
+	*exec.SqlJob
+	//*exec.JobBuilder
+	//where      expr.Node
+	//children exec.Tasks
+	//writer   models.ResultWriter
 }
-
 */
-
 // Create Job made up of sub-tasks in DAG that is the
 //   plan for execution of this query/job
-func BuildSqlJob(svr *models.ServerCtx, schemaDb, sqlText string) (*Builder, error) {
+func BuildSqlJob(svr *models.ServerCtx, schemaDb, sqlText string) (*exec.SqlJob, error) {
 
-	//return exec.BuildSqlProjectedJob(svr.RtConf, schemaDb, sqlText)
+	return exec.BuildSqlProjectedJob(svr.RtConf, schemaDb, sqlText)
+	/*
+		stmt, err := expr.ParseSql(sqlText)
+		if err != nil {
+			u.Warnf("Could not parse: %v", err)
+			return nil, err
+		}
 
-	stmt, err := expr.ParseSql(sqlText)
-	if err != nil {
-		u.Warnf("Could not parse: %v", err)
-		return nil, err
-	}
+		sqlJob := &exec.SqlJob{
+			Stmt: stmt,
+			Conf: svr.RtConf,
+		}
+		execBuilder := exec.NewJobBuilder(svr.RtConf, schemaDb)
 
-	sqlJob := &exec.SqlJob{
-		Stmt: stmt,
-		Conf: svr.RtConf,
-	}
-	execBuilder := exec.NewJobBuilder(svr.RtConf, schemaDb)
+		builder := NewBuilder(svr, sqlJob, schemaDb)
+		builder.JobBuilder = execBuilder
 
-	builder := NewBuilder(svr, sqlJob, schemaDb)
-	builder.JobBuilder = execBuilder
+		//u.LogTracef(u.WARN, "BuildSqlJob: schema='%s'  %#v", schemaDb, builder.schema)
+		u.Debugf("BuildSqlJob: schema='%s'  %#v", schemaDb, builder.Schema)
+		task, err := stmt.Accept(builder)
+		if err != nil {
+			u.Warnf("Could not build %v", err)
+			return nil, err
+		}
+		if task == nil {
+			// If No Error, and no Exec Tasks, then we already wrote results
+			return nil, nil
+		}
+		tr, ok := task.(exec.TaskRunner)
+		if !ok {
+			return nil, fmt.Errorf("Could not convert %T to TaskRunner", task)
+		}
+		builder.RootTask = tr
 
-	//u.LogTracef(u.WARN, "BuildSqlJob: schema='%s'  %#v", schemaDb, builder.schema)
-	u.Debugf("BuildSqlJob: schema='%s'  %#v", schemaDb, builder.Schema)
-	task, err := stmt.Accept(builder)
-	if err != nil {
-		u.Warnf("Could not build %v", err)
-		return nil, err
-	}
-	if task == nil {
-		// If No Error, and no Exec Tasks, then we already wrote results
-		return nil, nil
-	}
-	tr, ok := task.(exec.TaskRunner)
-	if !ok {
-		return nil, fmt.Errorf("Could not convert %T to TaskRunner", task)
-	}
-	builder.RootTask = tr
-
-	return builder, nil
+		return builder, nil
+	*/
 
 }
 
+/*
 // This is a Sql Plan Builder that chooses backends
 //   and routes/manages Requests
 type Builder struct {
@@ -172,3 +166,4 @@ func (m *Builder) VisitCommand(stmt *expr.SqlCommand) (expr.Task, error) {
 	tasks := make(exec.Tasks, 0)
 	return exec.NewSequential("sys-command", tasks), nil
 }
+*/

--- a/pkg/backends/build_mutate.go
+++ b/pkg/backends/build_mutate.go
@@ -22,7 +22,7 @@ func (m *Builder) VisitInsert(stmt *expr.SqlInsert) (expr.Task, error) {
 	tasks := make(exec.Tasks, 0)
 
 	tableName := strings.ToLower(stmt.Table)
-	tbl, err := m.schema.Table(tableName)
+	tbl, err := m.Schema.Table(tableName)
 	if err != nil {
 		u.Warnf("error finding table %v", err)
 		return nil, err
@@ -58,7 +58,7 @@ func (m *Builder) VisitUpdate(stmt *expr.SqlUpdate) (expr.Task, error) {
 	tasks := make(exec.Tasks, 0)
 
 	tableName := strings.ToLower(stmt.Table)
-	tbl, err := m.schema.Table(tableName)
+	tbl, err := m.Schema.Table(tableName)
 	if err != nil {
 		u.Warnf("error finding table %v", err)
 		return nil, err
@@ -97,7 +97,7 @@ func (m *Builder) VisitUpsert(stmt *expr.SqlUpsert) (expr.Task, error) {
 func (m *Builder) VisitDelete(stmt *expr.SqlDelete) (expr.Task, error) {
 	u.Debugf("VisitDelete %+v", stmt)
 	tasks := make(exec.Tasks, 0)
-	tbl, err := m.schema.Table(strings.ToLower(stmt.Table))
+	tbl, err := m.Schema.Table(strings.ToLower(stmt.Table))
 	if err != nil {
 		u.Warnf("error finding table %v", err)
 		return nil, err

--- a/pkg/backends/build_mutate.go
+++ b/pkg/backends/build_mutate.go
@@ -15,7 +15,7 @@ var (
 	_ = u.EMPTY
 )
 
-func (m *Builder) VisitInsert(stmt *expr.SqlInsert) (interface{}, error) {
+func (m *Builder) VisitInsert(stmt *expr.SqlInsert) (expr.Task, error) {
 
 	u.Debugf("VisitInsert %s", stmt)
 	//u.Debugf("VisitInsert %T  %s\n%#v", stmt, stmt.String(), stmt)
@@ -49,10 +49,10 @@ func (m *Builder) VisitInsert(stmt *expr.SqlInsert) (interface{}, error) {
 		return nil, fmt.Errorf("%T Must Implement Upsert or SourceMutation", tbl.SourceSchema.DS)
 	}
 
-	return tasks, nil
+	return exec.NewSequential("insert", tasks), nil
 }
 
-func (m *Builder) VisitUpdate(stmt *expr.SqlUpdate) (interface{}, error) {
+func (m *Builder) VisitUpdate(stmt *expr.SqlUpdate) (expr.Task, error) {
 	u.Debugf("VisitUpdate %+v", stmt)
 	//u.Debugf("VisitUpdate %T  %s\n%#v", stmt, stmt.String(), stmt)
 	tasks := make(exec.Tasks, 0)
@@ -86,15 +86,15 @@ func (m *Builder) VisitUpdate(stmt *expr.SqlUpdate) (interface{}, error) {
 		return nil, fmt.Errorf("%T Must Implement Upsert or SourceMutation", tbl.SourceSchema.DS)
 	}
 
-	return tasks, nil
+	return exec.NewSequential("update", tasks), nil
 }
 
-func (m *Builder) VisitUpsert(stmt *expr.SqlUpsert) (interface{}, error) {
+func (m *Builder) VisitUpsert(stmt *expr.SqlUpsert) (expr.Task, error) {
 	u.Debugf("VisitUpsert %+v", stmt)
 	return nil, ErrNotImplemented
 }
 
-func (m *Builder) VisitDelete(stmt *expr.SqlDelete) (interface{}, error) {
+func (m *Builder) VisitDelete(stmt *expr.SqlDelete) (expr.Task, error) {
 	u.Debugf("VisitDelete %+v", stmt)
 	tasks := make(exec.Tasks, 0)
 	tbl, err := m.schema.Table(strings.ToLower(stmt.Table))
@@ -124,5 +124,5 @@ func (m *Builder) VisitDelete(stmt *expr.SqlDelete) (interface{}, error) {
 		return nil, fmt.Errorf("%T Must Implement Deletion or SourceMutation", tbl.SourceSchema.DS)
 	}
 
-	return tasks, nil
+	return exec.NewSequential("delete", tasks), nil
 }

--- a/pkg/backends/build_mutate.go
+++ b/pkg/backends/build_mutate.go
@@ -1,5 +1,6 @@
 package backends
 
+/*
 import (
 	"fmt"
 	"strings"
@@ -126,3 +127,4 @@ func (m *Builder) VisitDelete(stmt *expr.SqlDelete) (expr.Task, error) {
 
 	return exec.NewSequential("delete", tasks), nil
 }
+*/

--- a/pkg/backends/build_select.go
+++ b/pkg/backends/build_select.go
@@ -1,26 +1,17 @@
 package backends
 
 import (
-	//"fmt"
-	//"strings"
+//u "github.com/araddon/gou"
 
-	u "github.com/araddon/gou"
-
-	//"github.com/araddon/qlbridge/datasource"
-	"github.com/araddon/qlbridge/datasource/membtree"
-	"github.com/araddon/qlbridge/exec"
-	"github.com/araddon/qlbridge/expr"
-	"github.com/araddon/qlbridge/value"
-
-	//"github.com/dataux/dataux/pkg/models"
+//"github.com/araddon/qlbridge/expr"
 )
 
-func (m *Builder) VisitSelect(stmt *expr.SqlSelect) (expr.Task, error) {
-	if stmt.SystemQry() {
-		return m.VisitSysVariable(stmt)
-	}
-	return m.JobBuilder.VisitSelect(stmt)
-}
+// func (m *Builder) VisitSelect(stmt *expr.SqlSelect) (expr.Task, error) {
+// 	if stmt.SystemQry() {
+// 		return m.VisitSysVariable(stmt)
+// 	}
+// 	return m.JobBuilder.VisitSelect(stmt)
+// }
 
 /*
 func (m *Builder) VisitSelect(stmt *expr.SqlSelect) (expr.Task, error) {
@@ -136,7 +127,7 @@ func (m *Builder) createProjection(stmt *expr.SqlSelect) *expr.Projection {
 	}
 	return p
 }
-*/
+
 func (m *Builder) VisitSelectDatabase(stmt *expr.SqlSelect) (expr.Task, error) {
 	u.Debugf("VisitSelectDatabase %+v", stmt)
 
@@ -162,3 +153,4 @@ func (m *Builder) VisitJoin(stmt *expr.SqlSource) (expr.Task, error) {
 	u.Debugf("VisitJoin %+v", stmt)
 	return nil, expr.ErrNotImplemented
 }
+*/

--- a/pkg/backends/build_select.go
+++ b/pkg/backends/build_select.go
@@ -1,19 +1,28 @@
 package backends
 
 import (
-	"fmt"
-	"strings"
+	//"fmt"
+	//"strings"
 
 	u "github.com/araddon/gou"
 
-	"github.com/araddon/qlbridge/datasource"
+	//"github.com/araddon/qlbridge/datasource"
 	"github.com/araddon/qlbridge/datasource/membtree"
 	"github.com/araddon/qlbridge/exec"
 	"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/value"
-	"github.com/dataux/dataux/pkg/models"
+
+	//"github.com/dataux/dataux/pkg/models"
 )
 
+func (m *Builder) VisitSelect(stmt *expr.SqlSelect) (expr.Task, error) {
+	if stmt.SystemQry() {
+		return m.VisitSysVariable(stmt)
+	}
+	return m.JobBuilder.VisitSelect(stmt)
+}
+
+/*
 func (m *Builder) VisitSelect(stmt *expr.SqlSelect) (expr.Task, error) {
 
 	if sysVar := stmt.SysVariable(); len(sysVar) > 0 {
@@ -22,7 +31,7 @@ func (m *Builder) VisitSelect(stmt *expr.SqlSelect) (expr.Task, error) {
 		return m.VisitSelectDatabase(stmt)
 	}
 
-	u.Debugf("VisitSelect %+v", stmt)
+	u.Debugf("dataux.VisitSelect %+v", stmt)
 
 	tasks := make(exec.Tasks, 0)
 
@@ -102,7 +111,7 @@ func (m *Builder) createProjection(stmt *expr.SqlSelect) *expr.Projection {
 	p := expr.NewProjection()
 	for _, from := range stmt.From {
 		//u.Infof("info: %#v", from)
-		tbl, err := m.schema.Table(strings.ToLower(from.Name))
+		tbl, err := m.Schema.Table(strings.ToLower(from.Name))
 		if err != nil {
 			u.Errorf("could not get table: %v", err)
 			return nil
@@ -127,14 +136,14 @@ func (m *Builder) createProjection(stmt *expr.SqlSelect) *expr.Projection {
 	}
 	return p
 }
-
+*/
 func (m *Builder) VisitSelectDatabase(stmt *expr.SqlSelect) (expr.Task, error) {
 	u.Debugf("VisitSelectDatabase %+v", stmt)
 
 	tasks := make(exec.Tasks, 0)
 	val := "NULL"
-	if m.schema != nil {
-		val = m.schema.Name
+	if m.Schema != nil {
+		val = m.Schema.Name
 	}
 	static := membtree.NewStaticDataValue(val, "database")
 	sourceTask := exec.NewSource(nil, static)

--- a/pkg/backends/build_show.go
+++ b/pkg/backends/build_show.go
@@ -1,5 +1,6 @@
 package backends
 
+/*
 import (
 	"database/sql/driver"
 	"fmt"
@@ -152,3 +153,4 @@ func (m *Builder) VisitDescribe(stmt *expr.SqlDescribe) (expr.Task, error) {
 
 	return exec.NewSequential("describe", tasks), nil
 }
+*/

--- a/pkg/backends/build_show.go
+++ b/pkg/backends/build_show.go
@@ -50,7 +50,7 @@ func (m *Builder) VisitShow(stmt *expr.SqlShow) (expr.Task, error) {
 	case strings.ToLower(stmt.Identity) == "databases":
 		// SHOW databases;
 		vals := make([][]driver.Value, 1)
-		vals[0] = []driver.Value{m.schema.Name}
+		vals[0] = []driver.Value{m.Schema.Name}
 		source := membtree.NewStaticDataSource("databases", 0, vals, []string{"Database"})
 		m.Projection = expr.NewProjection()
 		m.Projection.AddColumnShort("Database", value.StringType)
@@ -80,17 +80,17 @@ func (m *Builder) VisitShow(stmt *expr.SqlShow) (expr.Task, error) {
 		return exec.NewSequential("collation", tasks), nil
 	case strings.HasPrefix(raw, "show session"):
 		//SHOW SESSION VARIABLES LIKE 'lower_case_table_names';
-		source, proj := models.ShowVariables(m.schema, "lower_case_table_names", 0)
+		source, proj := models.ShowVariables(m.Schema, "lower_case_table_names", 0)
 		m.Projection = proj
 		tasks := make(exec.Tasks, 0)
 		sourceTask := exec.NewSource(nil, source)
 		u.Infof("source:  %#v", source)
 		tasks.Add(sourceTask)
 		return exec.NewSequential("session", tasks), nil
-	case strings.ToLower(stmt.Identity) == "tables" || strings.ToLower(stmt.Identity) == m.schema.Name:
+	case strings.ToLower(stmt.Identity) == "tables" || strings.ToLower(stmt.Identity) == m.Schema.Name:
 		if stmt.Full {
-			u.Debugf("show tables: %+v", m.schema)
-			tables := m.schema.Tables()
+			u.Debugf("show tables: %+v", m.Schema)
+			tables := m.Schema.Tables()
 			vals := make([][]driver.Value, len(tables))
 			row := 0
 			for _, tbl := range tables {
@@ -108,8 +108,8 @@ func (m *Builder) VisitShow(stmt *expr.SqlShow) (expr.Task, error) {
 			return exec.NewSequential("show-tables", tasks), nil
 		}
 		// SHOW TABLES;
-		//u.Debugf("show tables: %+v", m.schema)
-		source, proj := models.ShowTables(m.schema)
+		//u.Debugf("show tables: %+v", m.Schema)
+		source, proj := models.ShowTables(m.Schema)
 		m.Projection = proj
 		tasks := make(exec.Tasks, 0)
 		sourceTask := exec.NewSource(nil, source)
@@ -134,10 +134,10 @@ func (m *Builder) VisitShow(stmt *expr.SqlShow) (expr.Task, error) {
 func (m *Builder) VisitDescribe(stmt *expr.SqlDescribe) (expr.Task, error) {
 	u.Debugf("VisitDescribe %+v", stmt)
 
-	if m.schema == nil {
+	if m.Schema == nil {
 		return nil, ErrNoSchemaSelected
 	}
-	tbl, err := m.schema.Table(strings.ToLower(stmt.Identity))
+	tbl, err := m.Schema.Table(strings.ToLower(stmt.Identity))
 	if err != nil {
 		u.Errorf("could not get table: %v", err)
 		return nil, err

--- a/pkg/backends/datastore/datasource.go
+++ b/pkg/backends/datastore/datasource.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"database/sql/driver"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -56,6 +55,8 @@ type GoogleDSDataSource struct {
 	db             string
 	namespace      string
 	databases      []string
+	tablesLower    []string          // Lower cased
+	tablesOriginal map[string]string // google is case sensitive  map[lower]Original
 	cloudProjectId string
 	authConfig     *jwt.Config
 	dsCtx          context.Context
@@ -64,6 +65,12 @@ type GoogleDSDataSource struct {
 	schema         *datasource.SourceSchema
 	mu             sync.Mutex
 	closed         bool
+}
+
+type DatastoreMutator struct {
+	tbl *datasource.Table
+	sql expr.SqlStatement
+	ds  *GoogleDSDataSource
 }
 
 func NewGoogleDataStoreDataSource(schema *datasource.SourceSchema, conf *models.Config) models.DataSource {
@@ -182,11 +189,7 @@ func (m *GoogleDSDataSource) Open(tableName string) (datasource.SourceConn, erro
 	return gdsSource, nil
 }
 
-// func (m *GoogleDSDataSource) SourceTask(stmt *expr.SqlSelect) (models.SourceTask, error) {
-// 	return m.GetBySelect(stmt)
-// }
-
-func (m *GoogleDSDataSource) GetBySelect(stmt *expr.SqlSelect) (*ResultReader, error) {
+func (m *GoogleDSDataSource) selectQuery(stmt *expr.SqlSelect) (*ResultReader, error) {
 
 	//u.Debugf("get sourceTask for %v", stmt)
 	tblName := strings.ToLower(stmt.From[0].Name)
@@ -212,160 +215,7 @@ func (m *GoogleDSDataSource) GetBySelect(stmt *expr.SqlSelect) (*ResultReader, e
 
 func (m *GoogleDSDataSource) Table(table string) (*datasource.Table, error) {
 	//u.Debugf("get table for %s", table)
-	return m.loadTableSchema(table)
-}
-
-type DatastoreMutator struct {
-	tbl *datasource.Table
-	sql expr.SqlStatement
-	ds  *GoogleDSDataSource
-}
-
-// interface for SourceMutation
-func (m *GoogleDSDataSource) Create(tbl *datasource.Table, sql expr.SqlStatement) (datasource.Mutator, error) {
-	return &DatastoreMutator{
-		tbl: tbl,
-		sql: sql,
-		ds:  m,
-	}, nil
-}
-
-// interface for Upsert.Put()
-func (m *DatastoreMutator) Put(ctx context.Context, key datasource.Key, val interface{}) (datasource.Key, error) {
-
-	if key == nil {
-		u.Debugf("didn't have key?  %v", val)
-		//return nil, fmt.Errorf("Must have key for updates in DataStore")
-	}
-
-	if m.ds.schema == nil {
-		u.Warnf("must have schema")
-		return nil, fmt.Errorf("Must have schema for updates in DataStore")
-	}
-
-	var dskey *datastore.Key
-	props := make([]datastore.Property, 0)
-	var row, curRow []driver.Value
-	cols := m.tbl.Columns()
-
-	if key != nil {
-		dskey = datastore.NewKey(m.ds.dsCtx, m.tbl.NameOriginal, fmt.Sprintf("%v", key.Key()), 0, nil)
-	}
-
-	switch sqlReq := m.sql.(type) {
-	case *expr.SqlInsert:
-		cols = sqlReq.ColumnNames()
-	case *expr.SqlUpdate:
-		// need to fetch first?
-		sel := sqlReq.SqlSelect()
-		u.Debugf("new Select:  %s", sel)
-		res, err := m.ds.GetBySelect(sel)
-		if err != nil {
-			u.Errorf("wat?  %v", err)
-			return nil, err
-		}
-
-		if len(res.Vals) == 1 {
-			curRow = res.Vals[0]
-		} else {
-			u.Warnf("should only have one to update in Put(): %v", len(res.Vals))
-		}
-	}
-
-	switch valT := val.(type) {
-	case []driver.Value:
-		row = valT
-		//u.Infof("row len=%v   fieldlen=%v col len=%v", len(row), len(m.tbl.Fields), len(cols))
-		for _, f := range m.tbl.Fields {
-			for i, colName := range cols {
-				if f.Name == colName {
-
-					switch val := row[i].(type) {
-					case string, []byte, int, int64, bool, time.Time:
-						//u.Debugf("PUT field: i=%d col=%s row[i]=%v  T:%T", i, colName, row[i], row[i])
-						props = append(props, datastore.Property{Name: f.Name, Value: val})
-					case []value.Value:
-						by, err := json.Marshal(val)
-						if err != nil {
-							u.Errorf("Error converting field %v  err=%v", val, err)
-						}
-						//u.Debugf("PUT field: i=%d col=%s row[i]=%v  T:%T", i, colName, string(by), by)
-						props = append(props, datastore.Property{Name: f.Name, Value: by})
-					default:
-						u.Warnf("unsupported conversion: %T  %v", val, val)
-						props = append(props, datastore.Property{Name: f.Name, Value: val})
-					}
-
-					break
-				}
-			}
-		}
-		// Create the key by position?  HACK
-		dskey = datastore.NewKey(m.ds.dsCtx, m.tbl.NameOriginal, fmt.Sprintf("%v", row[0]), 0, nil)
-
-	case map[string]driver.Value:
-		for i, f := range m.tbl.Fields {
-			for colName, driverVal := range valT {
-				if f.Name == colName {
-					switch val := driverVal.(type) {
-					case string, []byte, int, int64, bool, time.Time:
-						u.Debugf("PUT field: i=%d col=%s val=%v  T:%T", i, colName, driverVal, driverVal)
-						curRow[i] = val
-					case []value.Value:
-						by, err := json.Marshal(val)
-						if err != nil {
-							u.Errorf("Error converting field %v  err=%v", val, err)
-						}
-						curRow[i] = by
-					default:
-						u.Warnf("unsupported conversion: %T  %v", val, val)
-
-					}
-					break
-				}
-			}
-			props = append(props, datastore.Property{Name: f.Name, Value: curRow[i]})
-		}
-
-	default:
-		u.Warnf("unsupported type: %T  %#v", val, val)
-		return nil, fmt.Errorf("Was not []driver.Value?  %T", val)
-	}
-
-	//u.Debugf("has key? sourcekey: %v  dskey:%#v", key, dskey)
-	//u.Debugf("dskey:  %s   table=%s", dskey, m.tbl.NameOriginal)
-	//u.Debugf("props:  %v", props)
-
-	pl := datastore.PropertyList(props)
-	dskey, err := m.ds.dsClient.Put(m.ds.dsCtx, dskey, &pl)
-	if err != nil {
-		u.Errorf("could not save? %v", err)
-		return nil, err
-	}
-	newKey := datasource.NewKeyCol("id", dskey.String())
-	return newKey, nil
-}
-
-func (m *DatastoreMutator) PutMulti(ctx context.Context, keys []datasource.Key, src interface{}) ([]datasource.Key, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (m *DatastoreMutator) Delete(key driver.Value) (int, error) {
-	dskey := datastore.NewKey(m.ds.dsCtx, m.tbl.NameOriginal, fmt.Sprintf("%v", key), 0, nil)
-	//u.Infof("dskey:  %s   table=%s", dskey, m.tbl.NameOriginal)
-	err := m.ds.dsClient.Delete(m.ds.dsCtx, dskey)
-	if err != nil {
-		u.Errorf("could not delete? %v", err)
-		return 0, err
-	}
-	return 1, nil
-}
-func (m *DatastoreMutator) DeleteExpression(where expr.Node) (int, error) {
-	delKey := datasource.KeyFromWhere(where)
-	if delKey != nil {
-		return m.Delete(delKey.Key())
-	}
-	return 0, fmt.Errorf("Could not delete with that where expression: %s", where)
+	return m.loadTableSchema(table, "")
 }
 
 func (m *GoogleDSDataSource) loadDatabases() error {
@@ -391,29 +241,43 @@ func (m *GoogleDSDataSource) loadDatabases() error {
 // Load only table/collection names, not full schema
 func (m *GoogleDSDataSource) loadTableNames() error {
 
-	tables := make([]string, 0)
+	tablesLower := make([]string, 0)
+	tablesOriginal := make(map[string]string)
 	rows := pageQuery(m.dsClient.Run(m.dsCtx, datastore.NewQuery("__kind__")))
 	for _, row := range rows {
 		if !strings.HasPrefix(row.key.Name(), "__") {
-			//u.Warnf("found table %s  %#v", row.key.Name(), row.key)
-			tables = append(tables, row.key.Name())
-			m.loadTableSchema(row.key.Name())
+			tableLower := strings.ToLower(row.key.Name())
+			//u.Debugf("found table %q  %#v", tableLower, row.key)
+			tablesLower = append(tablesLower, tableLower)
+			tablesOriginal[tableLower] = row.key.Name()
+			m.loadTableSchema(tableLower, row.key.Name())
 		}
-
 	}
+	m.tablesLower = tablesLower
+	m.tablesOriginal = tablesOriginal
 	return nil
 }
 
-func titleCase(table string) string {
-	table = strings.ToLower(table)
-	return strings.ToUpper(table[0:1]) + table[1:]
-}
+func (m *GoogleDSDataSource) loadTableSchema(tableLower, tableOriginal string) (*datasource.Table, error) {
 
-func (m *GoogleDSDataSource) loadTableSchema(table string) (*datasource.Table, error) {
+	if tableOriginal == "" {
+		name, ok := m.tablesOriginal[tableLower]
+		if !ok {
+			m.loadTableNames()
+			if name, ok = m.tablesOriginal[tableLower]; !ok {
+				return nil, fmt.Errorf("That table %q not found", tableLower)
+			}
+		}
+		tableOriginal = name
+	}
 
-	//u.LogTracef(u.WARN, "hello %q", table)
 	if m.schema == nil {
 		return nil, fmt.Errorf("no schema in use")
+	}
+
+	tbl, _ := m.schema.Table(tableLower)
+	if tbl != nil {
+		return tbl, nil
 	}
 
 	/*
@@ -422,11 +286,13 @@ func (m *GoogleDSDataSource) loadTableSchema(table string) (*datasource.Table, e
 		TODO:
 			- Need to recurse through enough records to get good idea of types
 	*/
-	tbl := datasource.NewTable(table, m.schema)
+	u.Debugf("loadTableSchema lower:%q original:%q", tableLower, tableOriginal)
+	tbl = datasource.NewTable(tableOriginal, m.schema)
+	colNames := make([]string, 0)
 
 	// We are going to scan this table, introspecting a few rows
 	// to see what types they might be
-	props := pageQuery(m.dsClient.Run(m.dsCtx, datastore.NewQuery(table).Limit(20)))
+	props := pageQuery(m.dsClient.Run(m.dsCtx, datastore.NewQuery(tableOriginal).Limit(20)))
 	for _, row := range props {
 
 		for _, p := range row.props {
@@ -474,17 +340,25 @@ func (m *GoogleDSDataSource) loadTableSchema(table string) (*datasource.Table, e
 				tbl.AddField(datasource.NewField(colName, value.ByteSliceType, 256, "[]byte"))
 				tbl.AddValues([]driver.Value{colName, "binary", "NO", "", "", "[]byte"})
 			default:
-				u.Warnf("%T  %#v", val, p)
+				u.Warnf("gds unknown type %T  %#v", val, p)
 			}
+			colNames = append(colNames, colName)
 		}
 	}
-	if len(tbl.FieldMap) > 0 {
-		//u.Infof("caching schema:%p   %q", m.schema, table)
-		m.schema.AddTable(tbl)
-		return tbl, nil
-	}
+	//if len(tbl.FieldMap) > 0 {
 
-	return nil, fmt.Errorf("not found")
+	u.Infof("caching schema:%p   %q", m.schema, tableOriginal)
+	m.schema.AddTable(tbl)
+	tbl.SetColumns(colNames)
+	return tbl, nil
+	//}
+
+	//return nil, fmt.Errorf("not found")
+}
+
+func titleCase(table string) string {
+	table = strings.ToLower(table)
+	return strings.ToUpper(table[0:1]) + table[1:]
 }
 
 func discoverType(iVal interface{}) value.ValueType {
@@ -554,71 +428,3 @@ func (m *schemaType) Load(props []datastore.Property) error {
 func (m *schemaType) Save() ([]datastore.Property, error) {
 	return nil, nil
 }
-
-/*
-func (m *GoogleDSDataSource) Put(ctx context.Context, key datasource.Key, row interface{}) (datasource.Key, error) {
-	// TODO:
-	if key == nil {
-		u.Debugf("put: %T", ctx)
-		u.Warnf("must have key?  %v", row)
-		return nil, fmt.Errorf("Must have key for inserts in DataStore")
-	}
-	if m.schema == nil {
-		u.Warnf("must have schema")
-		return nil, fmt.Errorf("Must have schema for inserts in DataStore")
-	}
-	//key := datastore.NewKey(ctx, ArticleKind, title, 0, nil)
-	//a := &tu.Article{fmt.Sprintf("article_%v", i), "auto", 22, 75, false, []string{"news", "sports"}, n, &n, 55.5, ev, &body}
-	//key, err := client.Put(ctx, articleKey(a.Title), &Article{a})
-	m.dsClient.Put(m.dsCtx, key, row)
-	return nil, nil
-}
-func (m *GoogleDSDataSource) PutMulti(ctx context.Context, keys []datasource.Key, src interface{}) ([]datasource.Key, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-// Interface for Deletion
-func (m *GoogleDSDataSource) Delete(key driver.Value) (int, error) {
-	return 0, fmt.Errorf("not implemented")
-}
-func (m *GoogleDSDataSource) DeleteExpression(where expr.Node) (int, error) {
-	// evaluator := vm.Evaluator(where)
-	// deletedKeys := make([]driver.Value, 0)
-	// for idx, row := range m.data {
-	// 	msgCtx := datasource.NewSqlDriverMessageMapVals(uint64(idx), row, m.cols)
-	// 	whereValue, ok := evaluator(msgCtx)
-	// 	if !ok {
-	// 		u.Debugf("could not evaluate where: %v   %v", idx, msgCtx.Values())
-	// 		//return deletedCt, fmt.Errorf("Could not evaluate where clause")
-	// 		continue
-	// 	}
-	// 	switch whereVal := whereValue.(type) {
-	// 	case value.BoolValue:
-	// 		if whereVal.Val() == false {
-	// 			//this means do NOT delete
-	// 		} else {
-	// 			// Delete!
-	// 			indexVal := row[m.indexCol]
-	// 			deletedKeys = append(deletedKeys, indexVal)
-	// 		}
-	// 	case nil:
-	// 		// ??
-	// 	default:
-	// 		if whereVal.Nil() {
-	// 			// Doesn't match, so don't delete
-	// 		} else {
-	// 			u.Warnf("unknown type? %T", whereVal)
-	// 		}
-	// 	}
-	// }
-	// for _, deleteKey := range deletedKeys {
-	// 	//u.Debugf("calling delete: %v", deleteKey)
-	// 	if ct, err := m.Delete(deleteKey); err != nil {
-	// 		u.Errorf("Could not delete key: %v", deleteKey)
-	// 	} else if ct != 1 {
-	// 		u.Errorf("delete should have removed 1 key %v", deleteKey)
-	// 	}
-	// }
-	// return len(deletedKeys), nil
-	return 0, fmt.Errorf("not implemented")
-}
-*/

--- a/pkg/backends/datastore/datasource.go
+++ b/pkg/backends/datastore/datasource.go
@@ -418,9 +418,7 @@ type schemaType struct {
 func (m *schemaType) Load(props []datastore.Property) error {
 	m.Vals = make(map[string]interface{}, len(props))
 	m.props = props
-	//u.Infof("Load: %#v", props)
-	for i, p := range props {
-		u.Infof("%d prop: %#v", i, p)
+	for _, p := range props {
 		m.Vals[p.Name] = p.Value
 	}
 	return nil

--- a/pkg/backends/datastore/datasource.go
+++ b/pkg/backends/datastore/datasource.go
@@ -295,14 +295,14 @@ func (m *GoogleDSDataSource) loadTableSchema(tableLower, tableOriginal string) (
 	props := pageQuery(m.dsClient.Run(m.dsCtx, datastore.NewQuery(tableOriginal).Limit(20)))
 	for _, row := range props {
 
-		for _, p := range row.props {
+		for i, p := range row.props {
 			//u.Warnf("%#v ", p)
 			colName := strings.ToLower(p.Name)
 
 			if tbl.HasField(colName) {
 				continue
 			}
-			//u.Debugf("%d found col: %s %T=%v", i, colName, p.Value, p.Value)
+			u.Debugf("%d found col: %s %T=%v", i, colName, p.Value, p.Value)
 			switch val := p.Value.(type) {
 			case *datastore.Key:
 				//u.Debugf("found datastore.Key: %v='%#v'", colName, val)
@@ -347,7 +347,7 @@ func (m *GoogleDSDataSource) loadTableSchema(tableLower, tableOriginal string) (
 	}
 	//if len(tbl.FieldMap) > 0 {
 
-	u.Infof("caching schema:%p   %q", m.schema, tableOriginal)
+	u.Infof("caching schema:%p   %q  cols=%v", m.schema, tableOriginal, colNames)
 	m.schema.AddTable(tbl)
 	tbl.SetColumns(colNames)
 	return tbl, nil
@@ -419,8 +419,8 @@ func (m *schemaType) Load(props []datastore.Property) error {
 	m.Vals = make(map[string]interface{}, len(props))
 	m.props = props
 	//u.Infof("Load: %#v", props)
-	for _, p := range props {
-		//u.Infof("prop: %#v", p)
+	for i, p := range props {
+		u.Infof("%d prop: %#v", i, p)
 		m.Vals[p.Name] = p.Value
 	}
 	return nil

--- a/pkg/backends/datastore/datasource.go
+++ b/pkg/backends/datastore/datasource.go
@@ -37,12 +37,12 @@ var (
 	ErrNoSchema = fmt.Errorf("No schema or configuration exists")
 
 	// Ensure our Google DataStore implements datasource.DataSource interface
-	_ datasource.DataSource     = (*GoogleDSDataSource)(nil)
-	_ datasource.SourceMutation = (*GoogleDSDataSource)(nil)
+	_ datasource.DataSource = (*GoogleDSDataSource)(nil)
+	//_ datasource.SourceMutation = (*GoogleDSDataSource)(nil)
 	//_ datasource.Deletion       = (*GoogleDSDataSource)(nil)
 	//_ datasource.Scanner    = (*ResultReader)(nil)
 	// source
-	_ models.DataSource = (*GoogleDSDataSource)(nil)
+	//_ models.DataSource = (*GoogleDSDataSource)(nil)
 )
 
 func init() {
@@ -178,23 +178,13 @@ func (m *GoogleDSDataSource) Open(tableName string) (datasource.SourceConn, erro
 		return nil, fmt.Errorf("Could not find '%v'.'%v' schema", m.schema.Name, tableName)
 	}
 
-	//es := NewSqlToMgo(tbl, m.sess)
-	//u.Debugf("SqlToMgo: %#v", es)
-	// resp, err := es.Query(stmt, m.sess)
-	// if err != nil {
-	// 	u.Error(err)
-	// 	return nil, err
-	// }
-	//return es, nil
-	sqlDs := NewSqlToDatstore(tbl, m.dsClient, m.dsCtx)
-	return sqlDs, nil
-
-	return nil, nil
+	gdsSource := NewSqlToDatstore(tbl, m.dsClient, m.dsCtx)
+	return gdsSource, nil
 }
 
-func (m *GoogleDSDataSource) SourceTask(stmt *expr.SqlSelect) (models.SourceTask, error) {
-	return m.GetBySelect(stmt)
-}
+// func (m *GoogleDSDataSource) SourceTask(stmt *expr.SqlSelect) (models.SourceTask, error) {
+// 	return m.GetBySelect(stmt)
+// }
 
 func (m *GoogleDSDataSource) GetBySelect(stmt *expr.SqlSelect) (*ResultReader, error) {
 
@@ -217,7 +207,6 @@ func (m *GoogleDSDataSource) GetBySelect(stmt *expr.SqlSelect) (*ResultReader, e
 		u.Errorf("Google datastore query interpreter failed: %v", err)
 		return nil, err
 	}
-
 	return resp, nil
 }
 

--- a/pkg/backends/datastore/datastore_test.go
+++ b/pkg/backends/datastore/datastore_test.go
@@ -32,7 +32,7 @@ var (
 	ctx    context.Context
 	client *datastore.Client
 
-	DbConn = "root@tcp(127.0.0.1:13307)/datauxtest"
+	DbConn = "root@tcp(127.0.0.1:13307)/datauxtest?parseTime=true"
 
 	loadTestDataOnce sync.Once
 

--- a/pkg/backends/datastore/datastore_test.go
+++ b/pkg/backends/datastore/datastore_test.go
@@ -480,6 +480,8 @@ func TestUpdateSimple(t *testing.T) {
 		ValidateRowData: func() {},
 		ExpectRowCt:     1,
 	})
+	u.Infof("about to test post update")
+	return
 	validateQuerySpec(t, tu.QuerySpec{
 		Sql:         `select id, name, deleted, roles, created, updated from DataUxTestUser WHERE id = "user815"`,
 		ExpectRowCt: 1,

--- a/pkg/backends/datastore/datastore_test.go
+++ b/pkg/backends/datastore/datastore_test.go
@@ -472,7 +472,7 @@ func TestUpdateSimple(t *testing.T) {
 		Created time.Time
 		Updated time.Time
 	}{}
-	u.Warnf("about to insert")
+	//u.Warnf("about to insert")
 	validateQuerySpec(t, tu.QuerySpec{
 		Exec: `INSERT INTO DataUxTestUser 
 							(id, name, deleted, created, updated, roles) 
@@ -481,7 +481,7 @@ func TestUpdateSimple(t *testing.T) {
 		ValidateRowData: func() {},
 		ExpectRowCt:     1,
 	})
-	u.Warnf("about to test post update")
+	//u.Warnf("about to test post update")
 	//return
 	validateQuerySpec(t, tu.QuerySpec{
 		Sql:         `select id, name, deleted, roles, created, updated from DataUxTestUser WHERE id = "user815"`,
@@ -504,13 +504,13 @@ func TestUpdateSimple(t *testing.T) {
 		},
 		RowData: &data,
 	})
-	u.Warnf("about to update")
+	//u.Warnf("about to update")
 	validateQuerySpec(t, tu.QuerySpec{
 		Exec:            `UPDATE DataUxTestUser SET name = "was_updated", [deleted] = true WHERE id = "user815"`,
 		ValidateRowData: func() {},
 		ExpectRowCt:     1,
 	})
-	u.Warnf("about to final read")
+	//u.Warnf("about to final read")
 	validateQuerySpec(t, tu.QuerySpec{
 		Sql:         `SELECT id, name, deleted, roles, created, updated FROM DataUxTestUser WHERE id = "user815"`,
 		ExpectRowCt: 1,

--- a/pkg/backends/datastore/datastore_test.go
+++ b/pkg/backends/datastore/datastore_test.go
@@ -472,6 +472,7 @@ func TestUpdateSimple(t *testing.T) {
 		Created time.Time
 		Updated time.Time
 	}{}
+	u.Warnf("about to insert")
 	validateQuerySpec(t, tu.QuerySpec{
 		Exec: `INSERT INTO DataUxTestUser 
 							(id, name, deleted, created, updated, roles) 
@@ -480,8 +481,8 @@ func TestUpdateSimple(t *testing.T) {
 		ValidateRowData: func() {},
 		ExpectRowCt:     1,
 	})
-	u.Infof("about to test post update")
-	return
+	u.Warnf("about to test post update")
+	//return
 	validateQuerySpec(t, tu.QuerySpec{
 		Sql:         `select id, name, deleted, roles, created, updated from DataUxTestUser WHERE id = "user815"`,
 		ExpectRowCt: 1,
@@ -493,21 +494,31 @@ func TestUpdateSimple(t *testing.T) {
 		},
 		RowData: &data,
 	})
-
-	validateQuerySpec(t, tu.QuerySpec{
-		Exec:            `UPDATE DataUxTestUser SET name = "was_updated", [deleted] = true WHERE id = "user815"`,
-		ValidateRowData: func() {},
-		ExpectRowCt:     1,
-	})
-
 	validateQuerySpec(t, tu.QuerySpec{
 		Sql:         `SELECT id, name, deleted, roles, created, updated FROM DataUxTestUser WHERE id = "user815"`,
 		ExpectRowCt: 1,
 		ValidateRowData: func() {
 			u.Infof("%v", data)
 			assert.Tf(t, data.Id == "user815", "%v", data)
-			assert.Tf(t, data.Name == "was_updated", "%v", data)
-			assert.Tf(t, data.Deleted == true, "Not deleted? %v", data)
+			assert.Tf(t, data.Deleted == false, "Not deleted? %v", data)
+		},
+		RowData: &data,
+	})
+	u.Warnf("about to update")
+	validateQuerySpec(t, tu.QuerySpec{
+		Exec:            `UPDATE DataUxTestUser SET name = "was_updated", [deleted] = true WHERE id = "user815"`,
+		ValidateRowData: func() {},
+		ExpectRowCt:     1,
+	})
+	u.Warnf("about to final read")
+	validateQuerySpec(t, tu.QuerySpec{
+		Sql:         `SELECT id, name, deleted, roles, created, updated FROM DataUxTestUser WHERE id = "user815"`,
+		ExpectRowCt: 1,
+		ValidateRowData: func() {
+			u.Infof("%v", data)
+			assert.Tf(t, data.Id == "user815", "fr1 %v", data)
+			assert.Tf(t, data.Name == "was_updated", "fr2 %v", data)
+			assert.Tf(t, data.Deleted == true, "fr3 deleted? %v", data)
 		},
 		RowData: &data,
 	})

--- a/pkg/backends/datastore/resultreader.go
+++ b/pkg/backends/datastore/resultreader.go
@@ -186,7 +186,7 @@ func (m *ResultReader) Run(context *expr.Context) error {
 				for i, col := range cols {
 					if col.Name == prop.Name {
 						vals[i] = prop.Value
-						//u.Debugf("%-10s %T\t%v", col.Name, prop.Value, prop.Value)
+						u.Debugf("%-10s %T\t%v", col.Name, prop.Value, prop.Value)
 						break
 					}
 				}
@@ -243,7 +243,7 @@ func (m *Row) Load(props []datastore.Property) error {
 	m.props = props
 	//u.Infof("Load: %#v", props)
 	for i, p := range props {
-		//u.Infof("%d prop: %#v", i, p)
+		u.Infof("%d prop: %#v", i, p)
 		m.Vals[i] = p.Value
 	}
 	return nil

--- a/pkg/backends/elasticsearch/es_datasource.go
+++ b/pkg/backends/elasticsearch/es_datasource.go
@@ -60,6 +60,25 @@ func (m *ElasticsearchDataSource) Init() error {
 	return nil
 }
 
+func (m *ElasticsearchDataSource) Builder(stmt *expr.SqlSelect) (expr.SubVisitor, error) {
+
+	u.Debugf("get sourceTask for %v", stmt)
+	tblName := strings.ToLower(stmt.From[0].Name)
+
+	tbl, err := m.schema.Table(tblName)
+	if err != nil {
+		return nil, err
+	}
+	if tbl == nil {
+		u.Errorf("Could not find table for '%s'.'%s'", m.schema.Name, tblName)
+		return nil, fmt.Errorf("Could not find '%v'.'%v' schema", m.schema.Name, tblName)
+	}
+
+	es := NewSqlToEs(tbl)
+	u.Debugf("sqltoes: %#v", es)
+	return es, nil
+}
+
 func (m *ElasticsearchDataSource) SourceTask(stmt *expr.SqlSelect) (models.SourceTask, error) {
 
 	u.Debugf("get sourceTask for %v", stmt)

--- a/pkg/backends/elasticsearch/es_datasource.go
+++ b/pkg/backends/elasticsearch/es_datasource.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	// Ensure our ElasticsearchDataSource is a SourceTask type
-	_ models.DataSource = (*ElasticsearchDataSource)(nil)
+	// implement interfaces
+	_ datasource.DataSource = (*ElasticsearchDataSource)(nil)
 )
 
 const (
@@ -79,6 +79,7 @@ func (m *ElasticsearchDataSource) Builder(stmt *expr.SqlSelect) (expr.SubVisitor
 	return es, nil
 }
 
+/*
 func (m *ElasticsearchDataSource) SourceTask(stmt *expr.SqlSelect) (models.SourceTask, error) {
 
 	u.Debugf("get sourceTask for %v", stmt)
@@ -103,7 +104,7 @@ func (m *ElasticsearchDataSource) SourceTask(stmt *expr.SqlSelect) (models.Sourc
 
 	return resp, nil
 }
-
+*/
 func (m *ElasticsearchDataSource) Open(schemaName string) (datasource.SourceConn, error) {
 	//u.Debugf("Open(%v)", schemaName)
 	tbl, err := m.schema.Table(schemaName)

--- a/pkg/backends/elasticsearch/es_datasource.go
+++ b/pkg/backends/elasticsearch/es_datasource.go
@@ -4,11 +4,10 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	u "github.com/araddon/gou"
+
 	"github.com/araddon/qlbridge/datasource"
-	"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/value"
 	"github.com/dataux/dataux/pkg/models"
 )
@@ -60,51 +59,6 @@ func (m *ElasticsearchDataSource) Init() error {
 	return nil
 }
 
-func (m *ElasticsearchDataSource) Builder(stmt *expr.SqlSelect) (expr.SubVisitor, error) {
-
-	u.Debugf("get sourceTask for %v", stmt)
-	tblName := strings.ToLower(stmt.From[0].Name)
-
-	tbl, err := m.schema.Table(tblName)
-	if err != nil {
-		return nil, err
-	}
-	if tbl == nil {
-		u.Errorf("Could not find table for '%s'.'%s'", m.schema.Name, tblName)
-		return nil, fmt.Errorf("Could not find '%v'.'%v' schema", m.schema.Name, tblName)
-	}
-
-	es := NewSqlToEs(tbl)
-	u.Debugf("sqltoes: %#v", es)
-	return es, nil
-}
-
-/*
-func (m *ElasticsearchDataSource) SourceTask(stmt *expr.SqlSelect) (models.SourceTask, error) {
-
-	u.Debugf("get sourceTask for %v", stmt)
-	tblName := strings.ToLower(stmt.From[0].Name)
-
-	tbl, err := m.schema.Table(tblName)
-	if err != nil {
-		return nil, err
-	}
-	if tbl == nil {
-		u.Errorf("Could not find table for '%s'.'%s'", m.schema.Name, tblName)
-		return nil, fmt.Errorf("Could not find '%v'.'%v' schema", m.schema.Name, tblName)
-	}
-
-	es := NewSqlToEs(tbl)
-	u.Debugf("sqltoes: %#v", es)
-	resp, err := es.Query(stmt)
-	if err != nil {
-		u.Error(err)
-		return nil, err
-	}
-
-	return resp, nil
-}
-*/
 func (m *ElasticsearchDataSource) Open(schemaName string) (datasource.SourceConn, error) {
 	//u.Debugf("Open(%v)", schemaName)
 	tbl, err := m.schema.Table(schemaName)

--- a/pkg/backends/elasticsearch/es_test.go
+++ b/pkg/backends/elasticsearch/es_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 var (
-	loadTestData *bool   = flag.Bool("loadtestdata", false, "Load elasticsearch test data, only needed once")
-	eshost       *string = flag.String("host", "localhost", "Elasticsearch Server Host Address")
+	eshost *string = flag.String("host", "localhost", "Elasticsearch Server Host Address")
 )
 
 func init() {

--- a/pkg/backends/elasticsearch/es_test.go
+++ b/pkg/backends/elasticsearch/es_test.go
@@ -318,7 +318,7 @@ func TestSelectWhereBetween(t *testing.T) {
 		Sql:         `select actor, repository.name from github_push where repository.stargazers_count BETWEEN "1000" AND 1100;`,
 		ExpectRowCt: 20,
 		ValidateRowData: func() {
-			u.Debugf("%#v", data)
+			//u.Debugf("%#v", data)
 			assert.Tf(t, data.Name != "", "%v", data)
 			//assert.Tf(t, data.Ct == 74995 || data.Ct == 74994, "%v", data)
 		},

--- a/pkg/backends/elasticsearch/esresults.go
+++ b/pkg/backends/elasticsearch/esresults.go
@@ -17,9 +17,9 @@ import (
 var (
 	_ models.ResultProvider = (*ResultReader)(nil)
 
-	// Ensure we implement datasource.DataSource, Scanner
-	_ datasource.DataSource = (*ResultReader)(nil)
-	_ datasource.Scanner    = (*ResultReader)(nil)
+	// Ensure we implement Scanner
+	_ expr.Task          = (*ResultReader)(nil)
+	_ datasource.Scanner = (*ResultReader)(nil)
 )
 
 // Elasticsearch ResultProvider, adapts the elasticsearch http json
@@ -106,26 +106,8 @@ func (m *ResultReader) buildProjection() {
 	u.Debugf("leaving Columns:  %v", len(m.proj.Columns))
 }
 
-func (m *ResultReader) Tables() []string {
-	return nil
-}
-
 func (m *ResultReader) Columns() []string {
 	return m.cols
-}
-
-func (m *ResultReader) Projection() (*expr.Projection, error) {
-	m.buildProjection()
-	return m.proj, nil
-}
-
-func (m *ResultReader) Open(connInfo string) (datasource.SourceConn, error) {
-	panic("Not implemented")
-	return m, nil
-}
-
-func (m *ResultReader) Schema() *datasource.Schema {
-	return m.Req.tbl.Schema
 }
 
 func (m *ResultReader) CreateIterator(filter expr.Node) datasource.Iterator {

--- a/pkg/backends/elasticsearch/esresults.go
+++ b/pkg/backends/elasticsearch/esresults.go
@@ -99,10 +99,16 @@ func (m *ResultReader) buildProjection() {
 		}
 	}
 	m.proj.Columns = cols
+	colNames := make([]string, len(cols))
+	for i, col := range cols {
+		colNames[i] = col.Name
+	}
+	m.cols = colNames
 	u.Debugf("leaving Columns:  %v", len(m.proj.Columns))
 }
 
 func (m *ResultReader) Columns() []string {
+	m.buildProjection()
 	return m.cols
 }
 

--- a/pkg/backends/elasticsearch/esresults.go
+++ b/pkg/backends/elasticsearch/esresults.go
@@ -67,7 +67,7 @@ func (m *ResultReader) buildProjection() {
 	if sql.Star {
 		// Select Each field, grab fields from Table Schema
 		for _, fld := range m.Req.tbl.Fields {
-			u.Infof("found %#v", fld)
+			//u.Infof("found %#v", fld)
 			cols = append(cols, expr.NewResultColumn(fld.Name, len(cols), nil, fld.Type))
 		}
 	} else if sql.CountStar() {
@@ -87,7 +87,7 @@ func (m *ResultReader) buildProjection() {
 			// MultiValue returns are resultsets that have multiple rows for a single expression, ie top 10 terms for this field, etc
 			// if len(sql.GroupBy) > 0 {
 			// We store the Field Name Here
-			u.Debugf("why MultiValue Aggs? %#v", m.Req)
+			//u.Debugf("why MultiValue Aggs? %#v", m.Req)
 			cols = append(cols, expr.NewResultColumn("field_name", len(cols), nil, value.StringType))
 			cols = append(cols, expr.NewResultColumn("key", len(cols), nil, value.StringType)) // the value of the field
 			cols = append(cols, expr.NewResultColumn("count", len(cols), nil, value.IntType))
@@ -95,7 +95,7 @@ func (m *ResultReader) buildProjection() {
 	} else {
 		for _, col := range m.Req.sel.Columns {
 			if fld, ok := m.Req.tbl.FieldMap[col.SourceField]; ok {
-				u.Debugf("column: %#v", col)
+				//u.Debugf("column: %#v", col)
 				cols = append(cols, expr.NewResultColumn(col.SourceField, len(cols), col, fld.Type))
 			} else {
 				u.Debugf("Could not find: %v", col.String())
@@ -339,13 +339,13 @@ func (m *ResultReader) pageDocs() error {
 					}
 				} else {
 
-					u.Debugf("col.type %v type %v", key, col.Type.String())
+					//u.Debugf("col.type %v type %v", key, col.Type.String())
 
 					switch col.Type {
 					case value.StringType:
 
 						strVal := doc.String(key)
-						u.Debugf("strval: %s=%q", key, strVal)
+						//u.Debugf("strval: %s=%q", key, strVal)
 						if strVal != "" {
 							vals[fldI] = strVal
 						} else {
@@ -366,7 +366,7 @@ func (m *ResultReader) pageDocs() error {
 					case value.NumberType:
 						vals[fldI] = doc.Float64(key)
 					case value.ByteSliceType:
-						u.Debugf("blob?  %v", key)
+						//u.Debugf("blob?  %v", key)
 						if docVal := doc.Get(key); docVal != nil {
 							by, _ := json.Marshal(docVal)
 							vals[fldI] = string(by)
@@ -378,7 +378,7 @@ func (m *ResultReader) pageDocs() error {
 
 				fldI++
 			}
-			u.Infof("vals: %#v", vals)
+			//u.Debugf("vals: %#v", vals)
 			m.Vals = append(m.Vals, vals)
 		}
 	}

--- a/pkg/backends/elasticsearch/sqltoes.go
+++ b/pkg/backends/elasticsearch/sqltoes.go
@@ -202,7 +202,7 @@ func (m *SqlToEs) WalkSelectList() error {
 	m.aggs = esMap{}
 	for i := len(m.sel.Columns) - 1; i >= 0; i-- {
 		col := m.sel.Columns[i]
-		u.Debugf("i=%d of %d  %v %#v ", i, len(m.sel.Columns), col.Key(), col)
+		//u.Debugf("i=%d of %d  %v %#v ", i, len(m.sel.Columns), col.Key(), col)
 		if col.Expr != nil {
 			switch curNode := col.Expr.(type) {
 			// case *expr.NumberNode:
@@ -316,7 +316,7 @@ func (m *SqlToEs) WalkAggs(cur expr.Node) (q esMap, _ error) {
 //
 //  TODO:  think we need to separate Value Nodes from those that return es types?
 func (m *SqlToEs) WalkNode(cur expr.Node, q *esMap) (value.Value, error) {
-	u.Debugf("walkFilter: %#v", cur)
+	//u.Debugf("walkFilter: %#v", cur)
 	switch curNode := cur.(type) {
 	case *expr.NumberNode, *expr.StringNode:
 		nodeVal, ok := vm.Eval(nil, cur)
@@ -361,11 +361,11 @@ func (m *SqlToEs) walkFilterTri(node *expr.TriNode, q *esMap) (value.Value, erro
 	//u.Debugf("arg1? %v  ok?%v", arg1val, aok)
 	arg2val, bok := vm.Eval(nil, node.Args[1])
 	arg3val, cok := vm.Eval(nil, node.Args[2])
-	u.Debugf("walkTri: %v  %v %v %v", node, arg1val, arg2val, arg3val)
+	//u.Debugf("walkTri: %v  %v %v %v", node, arg1val, arg2val, arg3val)
 	if !aok || !bok || !cok {
 		return nil, fmt.Errorf("Could not evaluate args: %v", node.String())
 	}
-	u.Debugf("walkTri: %v  %v %v %v", node, arg1val, arg2val, arg3val)
+	//u.Debugf("walkTri: %v  %v %v %v", node, arg1val, arg2val, arg3val)
 	switch node.Operator.T {
 	case lex.TokenBetween:
 		*q = esMap{"range": esMap{arg1val.ToString(): esMap{"gte": arg2val.ToString(), "lte": arg3val.ToString()}}}
@@ -391,7 +391,7 @@ func (m *SqlToEs) walkMultiFilter(node *expr.MultiArgNode, q *esMap) (value.Valu
 
 	// First argument must be field name in this context
 	fldName := node.Args[0].String()
-	u.Debugf("walkMulti: %v", node.String())
+	//u.Debugf("walkMulti: %v", node.String())
 	switch node.Operator.T {
 	case lex.TokenIN:
 		//q = esMap{"range": esMap{arg1val.ToString(): esMap{"gte": arg2val.ToString(), "lte": arg3val.ToString()}}}
@@ -437,7 +437,7 @@ func (m *SqlToEs) walkFilterBinary(node *expr.BinaryNode, q *esMap) (value.Value
 		u.Warnf("not ok: %v  l:%v  r:%v", node, lhval, rhval)
 		return nil, fmt.Errorf("could not evaluate: %v", node.String())
 	}
-	u.Debugf("walkBinary: op:%q  node:%v  l:%v  r:%v  %T  %T", node.Operator.V, node, lhval, rhval, lhval, rhval)
+	//u.Debugf("walkBinary: op:%q  node:%v  l:%v  r:%v  %T  %T", node.Operator.V, node, lhval, rhval, lhval, rhval)
 	switch node.Operator.T {
 	case lex.TokenLogicAnd:
 		// this doesn't yet implement x AND y AND z

--- a/pkg/backends/elasticsearch/sqltoes.go
+++ b/pkg/backends/elasticsearch/sqltoes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/araddon/qlbridge/datasource"
 	"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/lex"
+	"github.com/araddon/qlbridge/plan"
 	"github.com/araddon/qlbridge/value"
 	"github.com/araddon/qlbridge/vm"
 )
@@ -19,8 +20,7 @@ var (
 	DefaultLimit = 20
 
 	// planner
-	//_ expr.SubVisitor = (*SqlToEs)(nil)
-	_ datasource.SourceSelectPlanner = (*SqlToEs)(nil)
+	_ plan.SourceSelectPlanner = (*SqlToEs)(nil)
 )
 
 type esMap map[string]interface{}
@@ -64,22 +64,11 @@ func chooseBackend(schema *datasource.SourceSchema) string {
 	return ""
 }
 
-func (m *SqlToEs) Projection() (*expr.Projection, error) {
-	return m.resp.proj, nil
-}
-
-func (m *SqlToEs) SubSelectVisitor() (expr.SubVisitor, error) {
-	return m, nil
-}
-
-func (m *SqlToEs) VisitSubSelect(from *expr.SqlSource) (expr.Task, expr.VisitStatus, error) {
-	return m.Query(from.Source)
-}
-
-func (m *SqlToEs) Query(req *expr.SqlSelect) (*ResultReader, expr.VisitStatus, error) {
+func (m *SqlToEs) VisitSourceSelect(sp *plan.SourcePlan) (expr.Task, expr.VisitStatus, error) {
 
 	var err error
-	m.sel = req
+	req := sp.SqlSource.Source
+	m.sel = sp.SqlSource.Source
 	if req.Limit == 0 {
 		req.Limit = DefaultLimit
 	}

--- a/pkg/backends/elasticsearch/sqltoes.go
+++ b/pkg/backends/elasticsearch/sqltoes.go
@@ -188,7 +188,7 @@ func (m *SqlToEs) VisitSourceSelect(sp *plan.SourcePlan) (expr.Task, expr.VisitS
 	// } else {
 	// 	resp.ScrollId = scrollId
 	// }
-	resp.Finalize()
+	//resp.Finalize()
 
 	return resp, expr.VisitFinal, nil
 }

--- a/pkg/backends/mongo/mgo_results.go
+++ b/pkg/backends/mongo/mgo_results.go
@@ -20,10 +20,8 @@ import (
 var (
 	_ models.ResultProvider = (*ResultReader)(nil)
 
-	// Ensure we implement datasource.DataSource, Scanner
+	// Ensure we implement TaskRunner
 	_ exec.TaskRunner = (*ResultReader)(nil)
-	//_ datasource.SchemaColumns = (*ResultReader)(nil)
-	//_ datasource.Scanner       = (*ResultReader)(nil)
 )
 
 // Mongo ResultReader implements result paging, reading

--- a/pkg/backends/mongo/mgo_results.go
+++ b/pkg/backends/mongo/mgo_results.go
@@ -112,7 +112,7 @@ func (m *ResultReader) Run(context *expr.Context) error {
 		if !iter.Next(&bm) {
 			break
 		}
-		u.Debugf("col? %v", bm)
+		//u.Debugf("col? %v", bm)
 		vals := make([]driver.Value, len(cols))
 		for i, col := range cols {
 			if val, ok := bm[col.Col.SourceField]; ok {

--- a/pkg/backends/mongo/mgo_source.go
+++ b/pkg/backends/mongo/mgo_source.go
@@ -13,7 +13,7 @@ import (
 
 	u "github.com/araddon/gou"
 	"github.com/araddon/qlbridge/datasource"
-	"github.com/araddon/qlbridge/expr"
+	//"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/value"
 	"github.com/dataux/dataux/pkg/models"
 )
@@ -22,8 +22,7 @@ var (
 	//
 	_ datasource.Scanner = (*ResultReader)(nil)
 	// Ensure our MongoDataSource is a datasource.DataSource type
-	_ datasource.DataSource          = (*MongoDataSource)(nil)
-	_ datasource.SourceSelectPlanner = (*MongoDataSource)(nil)
+	_ datasource.DataSource = (*MongoDataSource)(nil)
 
 	// DEPRECATE ME
 	//_ models.DataSource        = (*MongoDataSource)(nil)
@@ -208,7 +207,7 @@ func (m *MongoDataSource) Accept(plan expr.SubVisitor) (datasource.Scanner, erro
 	// }
 	return nil, fmt.Errorf("Not implemented")
 }
-*/
+
 
 func (m *MongoDataSource) SubSelectVisitor() (expr.SubVisitor, error) {
 	return nil, nil
@@ -239,9 +238,9 @@ func (m *MongoDataSource) SourceTask(stmt *expr.SqlSelect) (models.SourceTask, e
 
 	return resp, nil
 }
-
+*/
 func (m *MongoDataSource) Table(table string) (*datasource.Table, error) {
-	u.Debugf("get table for %s", table)
+	//u.Debugf("get table for %s", table)
 	return m.loadTableSchema(table)
 }
 

--- a/pkg/backends/mongo/mgo_source.go
+++ b/pkg/backends/mongo/mgo_source.go
@@ -19,11 +19,14 @@ import (
 )
 
 var (
+	//
+	_ datasource.Scanner = (*ResultReader)(nil)
 	// Ensure our MongoDataSource is a datasource.DataSource type
-	_ datasource.DataSource = (*MongoDataSource)(nil)
-	_ datasource.Scanner    = (*ResultReader)(nil)
-	// source
-	_ models.DataSource = (*MongoDataSource)(nil)
+	_ datasource.DataSource    = (*MongoDataSource)(nil)
+	_ datasource.SourcePlanner = (*MongoDataSource)(nil)
+
+	// DEPRECATE ME
+	//_ models.DataSource        = (*MongoDataSource)(nil)
 )
 
 const (
@@ -174,14 +177,9 @@ func (m *MongoDataSource) Open(collectionName string) (datasource.SourceConn, er
 		return nil, fmt.Errorf("Could not find '%v'.'%v' schema", m.schema.Name, collectionName)
 	}
 
-	es := NewSqlToMgo(tbl, m.sess)
-	//u.Debugf("SqlToMgo: %#v", es)
-	// resp, err := es.Query(stmt, m.sess)
-	// if err != nil {
-	// 	u.Error(err)
-	// 	return nil, err
-	// }
-	return es, nil
+	mgoSource := NewSqlToMgo(tbl, m.sess)
+	//u.Debugf("SqlToMgo: %T  %#v", mgoSource, mgoSource)
+	return mgoSource, nil
 }
 
 /*
@@ -211,8 +209,14 @@ func (m *MongoDataSource) Accept(plan expr.SubVisitor) (datasource.Scanner, erro
 	return nil, fmt.Errorf("Not implemented")
 }
 */
+
+func (m *MongoDataSource) Builder() (expr.SubVisitor, error) {
+	return nil, nil
+}
+
 func (m *MongoDataSource) SourceTask(stmt *expr.SqlSelect) (models.SourceTask, error) {
 
+	panic("deprecated")
 	u.Debugf("get sourceTask for %v", stmt)
 	tblName := strings.ToLower(stmt.From[0].Name)
 
@@ -237,7 +241,7 @@ func (m *MongoDataSource) SourceTask(stmt *expr.SqlSelect) (models.SourceTask, e
 }
 
 func (m *MongoDataSource) Table(table string) (*datasource.Table, error) {
-	//u.Debugf("get table for %s", table)
+	u.Debugf("get table for %s", table)
 	return m.loadTableSchema(table)
 }
 

--- a/pkg/backends/mongo/mgo_source.go
+++ b/pkg/backends/mongo/mgo_source.go
@@ -89,12 +89,10 @@ func (m *MongoDataSource) Close() error {
 	return nil
 }
 
-func (m *MongoDataSource) DataSource() datasource.DataSource {
-	return m
-}
-
-func (m *MongoDataSource) Tables() []string {
-	return m.schema.Tables()
+func (m *MongoDataSource) DataSource() datasource.DataSource { return m }
+func (m *MongoDataSource) Tables() []string                  { return m.schema.Tables() }
+func (m *MongoDataSource) Table(table string) (*datasource.Table, error) {
+	return m.loadTableSchema(table)
 }
 
 func (m *MongoDataSource) Open(collectionName string) (datasource.SourceConn, error) {
@@ -111,11 +109,6 @@ func (m *MongoDataSource) Open(collectionName string) (datasource.SourceConn, er
 	mgoSource := NewSqlToMgo(tbl, m.sess.Clone())
 	//u.Debugf("SqlToMgo: %T  %#v", mgoSource, mgoSource)
 	return mgoSource, nil
-}
-
-func (m *MongoDataSource) Table(table string) (*datasource.Table, error) {
-	//u.Debugf("get table for %s", table)
-	return m.loadTableSchema(table)
 }
 
 func (m *MongoDataSource) loadSchema() error {

--- a/pkg/backends/mongo/mgo_source.go
+++ b/pkg/backends/mongo/mgo_source.go
@@ -22,8 +22,8 @@ var (
 	//
 	_ datasource.Scanner = (*ResultReader)(nil)
 	// Ensure our MongoDataSource is a datasource.DataSource type
-	_ datasource.DataSource    = (*MongoDataSource)(nil)
-	_ datasource.SourcePlanner = (*MongoDataSource)(nil)
+	_ datasource.DataSource          = (*MongoDataSource)(nil)
+	_ datasource.SourceSelectPlanner = (*MongoDataSource)(nil)
 
 	// DEPRECATE ME
 	//_ models.DataSource        = (*MongoDataSource)(nil)
@@ -210,7 +210,7 @@ func (m *MongoDataSource) Accept(plan expr.SubVisitor) (datasource.Scanner, erro
 }
 */
 
-func (m *MongoDataSource) Builder() (expr.SubVisitor, error) {
+func (m *MongoDataSource) SubSelectVisitor() (expr.SubVisitor, error) {
 	return nil, nil
 }
 

--- a/pkg/backends/mongo/mgo_test.go
+++ b/pkg/backends/mongo/mgo_test.go
@@ -256,23 +256,28 @@ func TestSelectLimit(t *testing.T) {
 	})
 }
 
-func TestSelectAggs(t *testing.T) {
+/*
+func TestSelectAggsSimple(t *testing.T) {
 
 	// TODO:  Not implemented
 	t.Fail()
 	return
+	// db.article.aggregate([{"$group":{_id: null, count: {"$sum":1}}}]);
+	// db.article.aggregate([{"$group":{_id: "$author", count: {"$sum":1}}}]);
+
 	data := struct {
-		Oldest int `db:"oldest_repo"`
-		Card   int `db:"users_who_released"`
+		Ct     int    `db:"article_ct"`
+		Author string `db:"author"`
 	}{}
 	validateQuerySpec(t, QuerySpec{
-		Sql:         "select cardinality(`actor`) AS users_who_released, min(`repository.id`) as oldest_repo from github_release;",
-		ExpectRowCt: 1,
+		Sql:         "select author, count(*) AS article_ct from article group by author;",
+		ExpectRowCt: 3,
 		ValidateRowData: func() {
 			//u.Debugf("%v", data)
-			assert.Tf(t, data.Card == 1772, "%v", data)
-			assert.Tf(t, data.Oldest == 27, "%v", data)
-
+			switch data.Author {
+			case "bjorn":
+				assert.Tf(t, data.Ct == 2, "%v", data)
+			}
 		},
 		RowData: &data,
 	})
@@ -299,9 +304,7 @@ func TestSelectAggs(t *testing.T) {
 }
 
 func TestSelectAggsGroupBy(t *testing.T) {
-	/*
-		NOTE:   This fails because of parsing the response, not because request is bad
-	*/
+	// TODO implement
 	return
 	data := struct {
 		Actor string
@@ -332,7 +335,7 @@ func TestSelectAggsGroupBy(t *testing.T) {
 		RowData: &data2,
 	})
 }
-
+*/
 func TestSelectWhereEqual(t *testing.T) {
 	/*
 		data := struct {

--- a/pkg/backends/mongo/mgo_test.go
+++ b/pkg/backends/mongo/mgo_test.go
@@ -205,6 +205,8 @@ func TestSimpleRowSelect(t *testing.T) {
 		},
 		RowData: &data,
 	})
+
+	return
 	validateQuerySpec(t, QuerySpec{
 		Sql:         "select title, count, deleted from article WHERE `author` = \"aaron\" AND count = 22 ",
 		ExpectRowCt: 1,

--- a/pkg/backends/mongo/sql_to_mgo.go
+++ b/pkg/backends/mongo/sql_to_mgo.go
@@ -141,7 +141,7 @@ func (m *SqlToMgo) VisitSourceSelect(sp *plan.SourcePlan) (expr.Task, expr.Visit
 
 	resultReader := NewResultReader(m, query)
 	m.resp = resultReader
-	resultReader.Finalize()
+	//resultReader.Finalize()
 	return resultReader, expr.VisitFinal, nil
 }
 

--- a/pkg/backends/tests/multi_backend_test.go
+++ b/pkg/backends/tests/multi_backend_test.go
@@ -187,7 +187,7 @@ func TestMongoToEsJoin(t *testing.T) {
 		ValidateRowData: func() {
 			switch data.Actor {
 			case "araddon":
-				u.Debugf("arddon:  %#v", data)
+				u.Debugf("araddon:  %#v", data)
 				assert.Tf(t, data.Repo == "qlparser" || data.Repo == "dateparse", "%#v", data)
 			default:
 				//assert.Tf(t, false, "Should not have found this column: %#v", data)

--- a/pkg/frontends/mysql_handler.go
+++ b/pkg/frontends/mysql_handler.go
@@ -93,7 +93,7 @@ func (m *MySqlHandler) chooseCommand(writer models.ResultWriter, req *models.Req
 	cmd := req.Raw[0]
 	req.Raw = req.Raw[1:]
 
-	u.Debugf("chooseCommand: %v:%v", cmd, mysql.CommandString(cmd))
+	//u.Debugf("chooseCommand: %v:%v", cmd, mysql.CommandString(cmd))
 	switch cmd {
 	case mysql.COM_QUERY, mysql.COM_STMT_PREPARE:
 		return m.handleQuery(writer, string(req.Raw))
@@ -170,7 +170,7 @@ func (m *MySqlHandler) handleQuery(writer models.ResultWriter, sql string) (err 
 
 	switch stmt := job.Stmt.(type) {
 	case *expr.SqlSelect, *expr.SqlShow, *expr.SqlDescribe:
-		u.Debugf("adding mysql result writer: projection: %p", job.Projection)
+		//u.Debugf("adding mysql result writer: projection: %p", job.Projection)
 		resultWriter := NewMySqlResultWriter(writer, job.Projection, m.schema)
 		job.RootTask.Add(resultWriter)
 	case *expr.SqlInsert, *expr.SqlUpsert, *expr.SqlUpdate, *expr.SqlDelete:

--- a/pkg/frontends/mysql_handler.go
+++ b/pkg/frontends/mysql_handler.go
@@ -170,7 +170,7 @@ func (m *MySqlHandler) handleQuery(writer models.ResultWriter, sql string) (err 
 
 	switch stmt := job.Stmt.(type) {
 	case *expr.SqlSelect, *expr.SqlShow, *expr.SqlDescribe:
-		u.Debugf("adding mysql result writer: %#v", job.Projection)
+		u.Debugf("adding mysql result writer: projection: %p", job.Projection)
 		resultWriter := NewMySqlResultWriter(writer, job.Projection, m.schema)
 		job.RootTask.Add(resultWriter)
 	case *expr.SqlInsert, *expr.SqlUpsert, *expr.SqlUpdate, *expr.SqlDelete:

--- a/pkg/frontends/mysql_handler.go
+++ b/pkg/frontends/mysql_handler.go
@@ -172,11 +172,11 @@ func (m *MySqlHandler) handleQuery(writer models.ResultWriter, sql string) (err 
 	case *expr.SqlSelect, *expr.SqlShow, *expr.SqlDescribe:
 		//u.Debugf("adding mysql result writer: %#v", builder.Projection)
 		resultWriter := NewMySqlResultWriter(writer, builder.Projection, m.schema)
-		builder.Job.Tasks.Add(resultWriter)
+		builder.Job.RootTask.Add(resultWriter)
 	case *expr.SqlInsert, *expr.SqlUpsert, *expr.SqlUpdate, *expr.SqlDelete:
 		//u.Debugf("adding mysql result writer: %#v", builder.Projection)
 		resultWriter := NewMySqlExecResultWriter(writer, m.schema)
-		builder.Job.Tasks.Add(resultWriter)
+		builder.Job.RootTask.Add(resultWriter)
 	// case *sqlparser.Delete:
 	// 	return m.handleExec(stmt, sql, nil)
 	// case *sqlparser.Replace:

--- a/pkg/frontends/mysql_handler.go
+++ b/pkg/frontends/mysql_handler.go
@@ -170,7 +170,7 @@ func (m *MySqlHandler) handleQuery(writer models.ResultWriter, sql string) (err 
 
 	switch stmt := job.Stmt.(type) {
 	case *expr.SqlSelect, *expr.SqlShow, *expr.SqlDescribe:
-		//u.Debugf("adding mysql result writer: %#v", job.Projection)
+		u.Debugf("adding mysql result writer: %#v", job.Projection)
 		resultWriter := NewMySqlResultWriter(writer, job.Projection, m.schema)
 		job.RootTask.Add(resultWriter)
 	case *expr.SqlInsert, *expr.SqlUpsert, *expr.SqlUpdate, *expr.SqlDelete:

--- a/pkg/frontends/results_mysql.go
+++ b/pkg/frontends/results_mysql.go
@@ -110,7 +110,7 @@ func (m *MySqlResultWriter) WriteHeaders() error {
 		u.Warnf("no projection")
 	}
 	cols := m.projection.Columns
-	u.Debugf("proj: %p writing mysql headers: %v", m.projection, cols)
+	u.Debugf("projection: %p writing mysql headers %s", m.projection, m.projection)
 	if len(cols) == 0 {
 		u.Warnf("Wat?   no columns?   %v", 0)
 		return nil

--- a/pkg/frontends/results_mysql.go
+++ b/pkg/frontends/results_mysql.go
@@ -47,9 +47,9 @@ func (m *MySqlResultWriter) Close() error {
 
 	if m.Rs == nil || len(m.Rs.Fields) == 0 {
 		m.Rs = NewEmptyResultset(m.projection)
-		//u.Infof("nil resultwriter Close() has RS?%v rowct:%v", m.Rs == nil, len(m.Rs.RowDatas))
+		u.Infof("nil resultwriter Close() has RS?%v rowct:%v", m.Rs == nil, len(m.Rs.RowDatas))
 	} else {
-		//u.Infof("in mysql resultwriter Close() has RS?%v rowct:%v", m.Rs == nil, len(m.Rs.RowDatas))
+		u.Infof("in mysql resultwriter Close() has RS?%v rowct:%v", m.Rs == nil, len(m.Rs.RowDatas))
 	}
 	m.writer.WriteResult(m.Rs)
 	return nil
@@ -74,6 +74,7 @@ func resultWrite(m *MySqlResultWriter) exec.MessageHandler {
 		switch mt := msg.Body().(type) {
 		case *datasource.SqlDriverMessageMap:
 			m.Rs.AddRowValues(mt.Values())
+			//u.Debugf( "return from mysql.resultWrite")
 			return true
 		case map[string]driver.Value:
 			vals := make([]driver.Value, len(m.projection.Columns))
@@ -109,7 +110,7 @@ func (m *MySqlResultWriter) WriteHeaders() error {
 		u.Warnf("no projection")
 	}
 	cols := m.projection.Columns
-	//u.Debugf("writing mysql headers: %v", cols)
+	u.Debugf("proj: %p writing mysql headers: %v", m.projection, cols)
 	if len(cols) == 0 {
 		u.Warnf("Wat?   no columns?   %v", 0)
 		return nil

--- a/pkg/frontends/results_mysql.go
+++ b/pkg/frontends/results_mysql.go
@@ -56,7 +56,7 @@ func (m *MySqlResultWriter) Close() error {
 
 func resultWrite(m *MySqlResultWriter) exec.MessageHandler {
 
-	return func(_ *exec.Context, msg datasource.Message) bool {
+	return func(_ *expr.Context, msg datasource.Message) bool {
 
 		//u.Debugf("in resultWrite:  %#v", msg)
 		if !m.wroteHeaders {
@@ -221,7 +221,7 @@ func (m *MySqlExecResultWriter) Finalize() error {
 	return nil
 }
 func nilWriter(m *MySqlExecResultWriter) exec.MessageHandler {
-	return func(_ *exec.Context, msg datasource.Message) bool {
+	return func(_ *expr.Context, msg datasource.Message) bool {
 		u.Debugf("in nilWriter:  %#v", msg)
 		return false
 	}

--- a/pkg/frontends/results_mysql.go
+++ b/pkg/frontends/results_mysql.go
@@ -74,7 +74,7 @@ func resultWrite(m *MySqlResultWriter) exec.MessageHandler {
 
 		switch mt := msg.Body().(type) {
 		case *datasource.SqlDriverMessageMap:
-			u.Infof("write: %#v", mt.Values())
+			//u.Infof("write: %#v", mt.Values())
 			m.Rs.AddRowValues(mt.Values())
 			//u.Debugf( "return from mysql.resultWrite")
 			return true
@@ -112,7 +112,7 @@ func (m *MySqlResultWriter) WriteHeaders() error {
 		u.Warnf("no projection")
 	}
 	cols := m.projection.Proj.Columns
-	u.Debugf("projection: %p writing mysql headers %s", m.projection.Proj, m.projection.Proj)
+	//u.Debugf("projection: %p writing mysql headers %s", m.projection.Proj, m.projection.Proj)
 	if len(cols) == 0 {
 		u.Warnf("Wat?   no columns?   %v", 0)
 		return nil
@@ -125,7 +125,7 @@ func (m *MySqlResultWriter) WriteHeaders() error {
 			as = col.Col.As
 		}
 		m.Rs.FieldNames[col.Name] = i
-		u.Debugf("writeheader %s %v", col.Name, col.Type.String())
+		//u.Debugf("writeheader %s %v", col.Name, col.Type.String())
 		switch col.Type {
 		case value.IntType:
 			m.Rs.Fields = append(m.Rs.Fields, mysql.NewField(as, s.Name, s.Name, 32, mysql.MYSQL_TYPE_LONG))
@@ -163,7 +163,7 @@ func (m *MySqlResultWriter) Finalize() error {
 func NewEmptyResultset(pp *plan.Projection) *mysql.Resultset {
 
 	r := new(mysql.Resultset)
-	u.Debugf("projection: %#v", pp)
+	//u.Debugf("projection: %#v", pp)
 	r.Fields = make([]*mysql.Field, len(pp.Proj.Columns))
 	r.FieldNames = make(map[string]int, len(r.Fields))
 	r.Values = make([][]driver.Value, 0)
@@ -184,7 +184,7 @@ func NewEmptyResultset(pp *plan.Projection) *mysql.Resultset {
 		default:
 			r.Fields[i].Name = []byte(col.As)
 		}
-		u.Infof("field: %#v", col)
+		//u.Debugf("field: %#v", col)
 	}
 	return r
 }

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -7,7 +7,6 @@ import (
 	u "github.com/araddon/gou"
 
 	"github.com/araddon/qlbridge/datasource"
-	//"github.com/araddon/qlbridge/expr"
 )
 
 var (
@@ -20,19 +19,11 @@ var (
 // A backend data source provider that also provides schema
 type DataSource interface {
 	datasource.DataSource
-	//datasource.SchemaProvider
-	//datasource.SourceSelectPlanner
-	//datasource.SourceSelectPlanner
-	//Table(table string) (*datasource.Table, error)
-
-	// Get a Task for given expression
-	//SourceTask(stmt *expr.SqlSelect) (SourceTask, error)
 }
 
-type SourceTask interface {
-	//exec.TaskRunner
-	datasource.Scanner
-}
+// type SourceTask interface {
+// 	datasource.Scanner
+// }
 
 type DataSourceCreator func(*datasource.SourceSchema, *Config) DataSource
 

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -19,9 +19,9 @@ var (
 
 // A backend data source provider that also provides schema
 type DataSource interface {
-	//datasource.DataSource
-	datasource.SchemaProvider
-	datasource.SourceSelectPlanner
+	datasource.DataSource
+	//datasource.SchemaProvider
+	//datasource.SourceSelectPlanner
 	//datasource.SourceSelectPlanner
 	//Table(table string) (*datasource.Table, error)
 

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -21,7 +21,7 @@ var (
 type DataSource interface {
 	//datasource.DataSource
 	datasource.SchemaProvider
-	datasource.SourcePlanner
+	datasource.SourceSelectPlanner
 	//datasource.SourceSelectPlanner
 	//Table(table string) (*datasource.Table, error)
 

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -21,10 +21,6 @@ type DataSource interface {
 	datasource.DataSource
 }
 
-// type SourceTask interface {
-// 	datasource.Scanner
-// }
-
 type DataSourceCreator func(*datasource.SourceSchema, *Config) DataSource
 
 func DataSourceRegister(sourceType string, fn DataSourceCreator) {

--- a/pkg/models/datasource.go
+++ b/pkg/models/datasource.go
@@ -5,8 +5,9 @@ import (
 	"sync"
 
 	u "github.com/araddon/gou"
+
 	"github.com/araddon/qlbridge/datasource"
-	"github.com/araddon/qlbridge/expr"
+	//"github.com/araddon/qlbridge/expr"
 )
 
 var (
@@ -18,11 +19,14 @@ var (
 
 // A backend data source provider that also provides schema
 type DataSource interface {
-	datasource.DataSource
-	Table(table string) (*datasource.Table, error)
+	//datasource.DataSource
+	datasource.SchemaProvider
+	datasource.SourcePlanner
+	//datasource.SourceSelectPlanner
+	//Table(table string) (*datasource.Table, error)
 
 	// Get a Task for given expression
-	SourceTask(stmt *expr.SqlSelect) (SourceTask, error)
+	//SourceTask(stmt *expr.SqlSelect) (SourceTask, error)
 }
 
 type SourceTask interface {

--- a/pkg/models/results.go
+++ b/pkg/models/results.go
@@ -1,35 +1,7 @@
 package models
 
-import (
-	"database/sql/driver"
-)
-
 type ResultWriter interface {
 	WriteResult(Result) error
 }
 
 type Result interface{}
-
-// ResultProvider is a Result Interface for bridging between backends/frontends
-//  - Next() same as database/sql driver interface for populating values
-//  - schema, we need col/data-types to write headers, typed interfaces
-type ResultProvider interface {
-	// The underlying schema
-	//Schema() *Schema
-	// Columns returns a definition for columns in this result
-	//Columns() []*ResultColumn
-
-	// Close closes the result provider
-	Close() error
-
-	// Next is called to populate the next row of data into
-	// the provided slice. The provided slice will be the same
-	// size as the Columns() are wide.
-	//
-	// The dest slice may be populated only with
-	// a driver Value type, but excluding string.
-	// All string values must be converted to []byte.
-	//
-	// Next should return io.EOF when there are no more rows.
-	Next(dest []driver.Value) error
-}

--- a/pkg/models/results.go
+++ b/pkg/models/results.go
@@ -2,15 +2,7 @@ package models
 
 import (
 	"database/sql/driver"
-
-	//u "github.com/araddon/gou"
-	//"github.com/araddon/qlbridge/expr"
-	//"github.com/araddon/qlbridge/value"
 )
-
-// type ResultSession interface {
-// 	ResultProvider() ResultProvider
-// }
 
 type ResultWriter interface {
 	WriteResult(Result) error
@@ -41,18 +33,3 @@ type ResultProvider interface {
 	// Next should return io.EOF when there are no more rows.
 	Next(dest []driver.Value) error
 }
-
-// type ValsMessage struct {
-// 	Vals []driver.Value
-// 	Id   uint64
-// }
-
-// func (m ValsMessage) Key() uint64       { return m.Id }
-// func (m ValsMessage) Body() interface{} { return m.Vals }
-
-// type ResultColumn struct {
-// 	Name   string          // Original path/name for query field
-// 	Pos    int             // Ordinal position in sql statement
-// 	SqlCol *expr.Column    // the original sql column
-// 	Type   value.ValueType // Type
-// }

--- a/pkg/models/schema.go
+++ b/pkg/models/schema.go
@@ -1,12 +1,8 @@
 package models
 
 import (
-	"database/sql/driver"
-
 	u "github.com/araddon/gou"
 	"github.com/araddon/qlbridge/datasource"
-	"github.com/araddon/qlbridge/datasource/membtree"
-	"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/value"
 
 	"github.com/dataux/dataux/vendor/mixer/mysql"
@@ -16,6 +12,7 @@ var (
 	_ = u.EMPTY
 )
 
+/*
 func DescribeTable(tbl *datasource.Table) (*membtree.StaticDataSource, *expr.Projection) {
 	if len(tbl.Fields) == 0 {
 		u.Warnf("NO Fields!!!!! for %s p=%p", tbl.Name, tbl)
@@ -50,14 +47,14 @@ func ShowTables(s *datasource.Schema) (*membtree.StaticDataSource, *expr.Project
 }
 
 func ShowVariables(s *datasource.Schema, name string, val driver.Value) (*membtree.StaticDataSource, *expr.Projection) {
-	/*
+	/ *
 	   MariaDB [(none)]> SHOW SESSION VARIABLES LIKE 'lower_case_table_names';
 	   +------------------------+-------+
 	   | Variable_name          | Value |
 	   +------------------------+-------+
 	   | lower_case_table_names | 0     |
 	   +------------------------+-------+
-	*/
+	* /
 	vals := make([][]driver.Value, 1)
 	vals[0] = []driver.Value{name, val}
 	dataSource := membtree.NewStaticDataSource("schematables", 0, vals, []string{"Variable_name", "Value"})
@@ -66,6 +63,7 @@ func ShowVariables(s *datasource.Schema, name string, val driver.Value) (*membtr
 	p.AddColumnShort("Value", value.StringType)
 	return dataSource, p
 }
+*/
 
 func TableToMysqlResultset(tbl *datasource.Table) *mysql.Resultset {
 	rs := new(mysql.Resultset)

--- a/pkg/testdata/importgithub.go
+++ b/pkg/testdata/importgithub.go
@@ -1,4 +1,4 @@
-package testdata
+package main
 
 import (
 	"bufio"
@@ -73,7 +73,6 @@ func PutGithubMappings(host string) {
 		    }
 		}`)
 	}
-
 }
 
 //  Load a set of historical data from Github into Elasticsearch
@@ -102,8 +101,8 @@ func LoadGithubToEs(host string, year, month, daysToImport, hoursToImport int) {
 	}()
 
 	//http://data.githubarchive.org/2015-01-01-15.json.g
-	for day := 1; day <= daysToImport; day++ {
-		for hr := 0; hr < hoursToImport; hr++ {
+	for day := 2; day <= daysToImport; day++ {
+		for hr := 7; hr < hoursToImport; hr++ {
 			downUrl := fmt.Sprintf("http://data.githubarchive.org/%d-%02d-%02d-%d.json.gz", year, month, day, hr)
 
 			u.Info("Starting Download ", downUrl)

--- a/pkg/testdata/main.go
+++ b/pkg/testdata/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"flag"
+	u "github.com/araddon/gou"
+)
+
+var (
+	eshost *string = flag.String("host", "localhost", "Elasticsearch Server Host Address")
+)
+
+func main() {
+	flag.Parse()
+	u.SetupLogging("info")
+	LoadGithubToEsOnce(*eshost)
+}

--- a/pkg/testutil/testsetup.go
+++ b/pkg/testutil/testsetup.go
@@ -53,7 +53,7 @@ func Setup() {
 	setup.Do(func() {
 		flag.Parse()
 		if *veryVerbose {
-			u.SetupLogging(*logLevel)
+			u.SetupLoggingLong(*logLevel)
 			u.SetColorOutput()
 		} else {
 			u.SetupLogging("warn")

--- a/vendor/mixer/mysql/resultset.go
+++ b/vendor/mixer/mysql/resultset.go
@@ -54,11 +54,11 @@ func ValuesToRowData(values []driver.Value, fields []*Field) (RowData, error) {
 	var err error
 	//var isNull, isUnsigned bool
 	if len(values) != len(fields) {
-		// for _, fld := range fields {
-		// 	u.Debugf("field:  %v %v", fld.FieldName, fld.Name)
-		// }
+		for _, fld := range fields {
+			u.Debugf("field:  %v %v", fld.FieldName, fld.Name)
+		}
 		//panic("wtf")
-		u.Errorf("Number of values doesn't match number of fields:  fields:%v vals:%v   \n%#v", len(fields), len(values), values)
+		u.LogTracef(u.ERROR, "Number of values doesn't match number of fields:  fields:%v vals:%v   \n%#v", len(fields), len(values), values)
 		//return nil, fmt.Errorf("Number of values doesn't match number of fields:  fields:%v vals:%v", len(fields), len(values))
 	}
 

--- a/vendor/mixer/proxy/conn.go
+++ b/vendor/mixer/proxy/conn.go
@@ -123,7 +123,7 @@ func (c *Conn) Run() {
 			return
 		}
 
-		u.Debugf("Run() -> handler.Handle(): %v", string(data))
+		//u.Debugf("Run() -> handler.Handle(): %v", string(data))
 		if err := c.handler.Handle(c, &models.Request{Raw: data}); err != nil {
 			u.Warnf("Handler() error %v", err)
 			if err != mysql.ErrBadConn {

--- a/vendor/mixer/proxy/conn.go
+++ b/vendor/mixer/proxy/conn.go
@@ -123,7 +123,7 @@ func (c *Conn) Run() {
 			return
 		}
 
-		//u.Debugf("Run() -> handler.Handle(): %v", string(data))
+		u.Debugf("Run() -> handler.Handle(): %v", string(data))
 		if err := c.handler.Handle(c, &models.Request{Raw: data}); err != nil {
 			u.Warnf("Handler() error %v", err)
 			if err != mysql.ErrBadConn {

--- a/vendor/mixer/proxy/listener.go
+++ b/vendor/mixer/proxy/listener.go
@@ -94,6 +94,7 @@ func (m *MysqlListener) Close() error {
 func (m *MysqlListener) OnConn(c net.Conn) {
 
 	conn := newConn(m, c)
+	u.Debugf("new conn p:%p", conn)
 
 	if !m.cfg.SupressRecover {
 		defer func() {


### PR DESCRIPTION
make it easier to write datasources by allowing re-usability, and poly-fill missing features on Visit interface instead of SourceTask interface

* [x] remove `SourceTask` 
* [x] ensure all schema related things moved to qlbridge
* [ ] re-implement @show, @@vars type queries using actual datasouce
* [ ] re-implement `set` commands
* [ ] migrate datasources
   * [x] mongo
   * [x] es
   * [ ] google datastore
