### PR TITLE
BigQuery uses [ identity escape syntax refs

### DIFF
--- a/backends/bigquery/README.md
+++ b/backends/bigquery/README.md
@@ -3,7 +3,7 @@ Google BigQuery Data source
 --------------------------------------
 
 Provides MySQL acess to [Google BigQuery](https://cloud.google.com/bigquery/)
-which opens up the usage of bigquery for bi tools that don't have native
+which opens up the usage of bigquery via standard sql allowing tools that don't have native
 bigquery clients.
 
 

--- a/backends/bigquery/bq_test.go
+++ b/backends/bigquery/bq_test.go
@@ -197,6 +197,18 @@ func TestSelectLimit(t *testing.T) {
 	})
 }
 
+func TestSelectEscapeSyntax(t *testing.T) {
+	data := struct {
+		Name string
+	}{}
+	validateQuerySpec(t, tu.QuerySpec{
+		Sql:             "select `name` from `bikeshare_stations` LIMIT 1;",
+		ExpectRowCt:     1,
+		ValidateRowData: func() {},
+		RowData:         &data,
+	})
+}
+
 func TestSelectGroupBy(t *testing.T) {
 	data := struct {
 		Landmark string

--- a/backends/bigquery/resultreader.go
+++ b/backends/bigquery/resultreader.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/araddon/qlbridge/datasource"
 	"github.com/araddon/qlbridge/exec"
+	"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/rel"
 	"github.com/araddon/qlbridge/value"
 )
@@ -129,7 +130,10 @@ func (m *ResultReader) Run() error {
 		u.Warnf("Could not create bigquery client billing_project=%q  err=%v", m.Req.s.billingProject, err)
 		return err
 	}
-	q := client.Query(sel.String())
+
+	bqWriter := expr.NewDialectWriter('"', '[')
+	sel.WriteDialect(bqWriter)
+	q := client.Query(bqWriter.String())
 
 	ctx := context.Background()
 	job, err := q.Run(ctx)

--- a/backends/bigquery/source.go
+++ b/backends/bigquery/source.go
@@ -49,6 +49,7 @@ type Source struct {
 	billingProject   string
 	dataProject      string
 	dataset          string
+	legacySyntax     bool
 	tables           []string // Lower cased
 	tablemap         map[string]*schema.Table
 	conf             *schema.ConfigSource
@@ -106,6 +107,8 @@ func (m *Source) Setup(ss *schema.SchemaSource) error {
 	if len(m.dataset) == 0 {
 		return fmt.Errorf("No 'dataset' for bigquery found in config %v", m.conf.Settings)
 	}
+
+	m.legacySyntax = m.conf.Settings.Bool("legacy_syntax")
 
 	m.loadSchema()
 	return nil


### PR DESCRIPTION
Refs #55 

Requires upstream https://github.com/araddon/qlbridge/pull/179

Change the big-query identity escape character to correct [ with DialectWriter.