### PR TITLE
Make Dockerfile build from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM golang:1.7
-MAINTAINER Aaron Raddon <araddon@gmail.com>
+FROM golang:1.9
 
-ADD backends/files/tables/tables/appearances/appearances.csv /vol/baseball/appearances.csv
+RUN \
+  go get -u -v github.com/golang/dep/cmd/dep
 
-ADD dataux.container.conf /etc/dataux.conf
+COPY . ${GOPATH}/src/github.com/dataux/dataux/
+WORKDIR ${GOPATH}/src/github.com/dataux/dataux/
 
-ADD dataux /dataux
-ENTRYPOINT ["/dataux","--config=/etc/dataux.conf"]
+RUN \
+  dep ensure -update -v && \
+  go build
+
+ENTRYPOINT [ "./dataux" ]


### PR DESCRIPTION
* Created Dockerfile following advice on #59.
* Removed ```MAINTAINER``` instruction, since it's deprecated.
* Removed ```--config``` switch from `ENTRYPOINT` to make the image more generic and the least opinionated possible.
* The ```go get``` for ```dep``` is isolated to take advantage of Docker build cache on each rebuild (faster development).
* Golang image version updated to 1.9, since ẁith 1.7 fails on build (```dep```?). Pinned to latest, anyway.

This PR would enable the following improvements:
* Easier onboarding to new developers, since building is trivial for those already in the Docker workflow, so hacking becomes easier.
* Enable creation of an [Automated Build](https://docs.docker.com/docker-hub/builds/) on Docker Hub to provide a public, built-from-source Docker image. It's an easy one-time process which requires a free Docker Hub account. I'll be glad to help, in need.
* If an AB is set up, providing a new and hands-free packaging method to distribute the software.

You can check & test my Docker Hub image here: https://hub.docker.com/r/pataquets/dataux-source/builds/